### PR TITLE
fix(wallet): segwit v0 instead of taproot as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A sweepr CLI for the hodlr that just wants to sweep the funds from a seed to an 
 
 ## Usage
 
+By default sweepr will generate segwit v0 addresses.
+In the future, when taproot is more widely adopted, this will be the default.
+
 ```bash
 $ sweepr --help
 A sweepr CLI for the hodlr that just wants to sweep the funds from a seed to an address

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -64,7 +64,7 @@ pub fn create_wallet<'a>(
 
     // generate external and internal descriptor from mnemonic
     let (external_descriptor, _ext_keymap) =
-        match descriptor!(tr((seed.clone(), derivation_path_external.clone())))
+        match descriptor!(wpkh((seed.clone(), derivation_path_external.clone())))
             .unwrap()
             .into_wallet_descriptor(&secp, network)
         {
@@ -72,7 +72,7 @@ pub fn create_wallet<'a>(
             Err(e) => panic!("Invalid external derivation path: {}", e),
         };
     let (internal_descriptor, _int_keymap) =
-        match descriptor!(tr((seed.clone(), derivation_path_internal.clone())))
+        match descriptor!(wpkh((seed.clone(), derivation_path_internal.clone())))
             .unwrap()
             .into_wallet_descriptor(&secp, network)
         {


### PR DESCRIPTION
This changes the default descriptor to build segwit v0 instead of taproot.